### PR TITLE
Configure travis to send devel to docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+
+language: python
+
+python:
+  - "3.6" 
+
+branches:
+  - master
+  - development
+  - /.*release.*/
+
+services:
+  - docker
+
+before_script:
+  - docker build -t pdf2front .
+
+script:
+  - docker run pdf2front npm run build
+ 
+deploy:
+  provider: script
+  script: bash scripts/deploy.sh
+  on:
+    branch: development
+
+addons:
+  apt:
+    packages:
+      - docker-ce

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ COPY pdf2cash_front/package.json /app/package.json
 
 RUN npm install 
 
+ADD pdf2cash_front/ /app/
 
+CMD npm run dev

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/PDF2CASH/PDF2CASH_FrontEnd.svg?branch=development)](https://travis-ci.org/PDF2CASH/PDF2CASH_FrontEnd)
 # PDF2CASHFrontEnd
 
 Repositório responsável por armazenar o código fonte do microserviço FrontEnd do projeto _PDF2CASH_.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,12 +4,9 @@ set -ev
 
 echo "Deployment init"
 
-pip install awscli
-export PATH=$PATH:$HOME/.local/bin
-echo $(aws ecr get-authorization-token --region us-east-2 --output text --query 'authorizationData[].authorizationToken' | base64 -d | cut -d: -f2) | docker login -u AWS https://742466423033.dkr.ecr.us-east-2.amazonaws.com --password-stdin
-docker tag pdf2front:latest 742466423033.dkr.ecr.us-east-2.amazonaws.com/pdf2cash:pdf2front
-docker push 742466423033.dkr.ecr.us-east-2.amazonaws.com/pdf2cash:pdf2front
-
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker tag pdf2front pdf2cash/pdf2front:latest
+docker push pdf2cash/pdf2front:latest
 
 
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ev
+
+echo "Deployment init"
+
+pip install awscli
+export PATH=$PATH:$HOME/.local/bin
+echo $(aws ecr get-authorization-token --region us-east-2 --output text --query 'authorizationData[].authorizationToken' | base64 -d | cut -d: -f2) | docker login -u AWS https://742466423033.dkr.ecr.us-east-2.amazonaws.com --password-stdin
+docker tag pdf2front:latest 742466423033.dkr.ecr.us-east-2.amazonaws.com/pdf2cash:pdf2front
+docker push 742466423033.dkr.ecr.us-east-2.amazonaws.com/pdf2cash:pdf2front
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This pull request add continuous deployment on development branch. Also github's "build badge" was added to README.md

related issues:
fga-eps-mds/2018.2-PDF2CASH#99
fga-eps-mds/2018.2-PDF2CASH#14
fga-eps-mds/2018.2-PDF2CASH#15